### PR TITLE
＜認証関連画面＞

### DIFF
--- a/questionanswer/public/css/question.css
+++ b/questionanswer/public/css/question.css
@@ -27,13 +27,25 @@ body {
   opacity: 0.8;
   font-size: 20px;
   display: block;
-  margin: 10px auto;
+  margin: 60px auto 30px;
   width: 200px;
   height: 50px;
 }
 .btn:hover {
   opacity: 1;
 }
+.btn.fsize {
+  font-size: 17px;
+}
+.btn.a-btn {
+  padding-top: 10px;
+  margin-top: 0;
+  background-color: #fff;
+  color: #59c4c5;
+}
 .padding-div {
-  padding-top: 50px;
+  padding-top: 55px;
+}
+.padding-auth {
+  padding-top: 30px;
 }

--- a/questionanswer/public/scss/question.scss
+++ b/questionanswer/public/scss/question.scss
@@ -37,15 +37,30 @@ body {
     opacity: 0.8;
     font-size: 20px;
     display: block;
-    margin: 10px auto;
+    margin: 60px auto 30px;
     width: 200px;
     height: 50px;
     
     &:hover {
         opacity: 1;
     }
+    
+    &.fsize {
+        font-size: 17px;
+    }
+    
+    &.a-btn {
+        padding-top: 10px;
+        margin-top: 0;
+        background-color: #FFF;
+        color: #59c4c5;
+    }
 }
 
 .padding-div {
-    padding-top: 50px;
+    padding-top: 55px;
+}
+
+.padding-auth {
+    padding-top: 30px;
 }

--- a/questionanswer/resources/views/auth/login.blade.php
+++ b/questionanswer/resources/views/auth/login.blade.php
@@ -2,7 +2,7 @@
 
 @section('content')
 <div class="container">
-    <div class="row justify-content-center">
+    <div class="row justify-content-center padding-auth">
         <div class="col-md-8">
             <div class="card">
                 <div class="card-header">{{ __('ログイン') }}</div>
@@ -51,20 +51,16 @@
                             </div>
                         </div>
 
-                        <div class="form-group row mb-0">
-                            <div class="col-md-6 offset-md-4">
-                                <button type="submit" class="btn btn-primary">
-                                    {{ __('ログイン') }}
-                                </button>
+                        <div class="form-group">
+                            <button type="submit" class="btn btn-primary">
+                                {{ __('ログイン') }}
+                            </button>
 
-                                @if (Route::has('password.request'))
-                                    <a style="text-decoration: none;" href="{{ route('password.request') }}">
-                                        <button class="btn btn-primary">
-                                            {{ __('パスワードを忘れた方') }}
-                                        </button>
-                                    </a>
-                                @endif
-                            </div>
+                            @if (Route::has('password.request'))
+                                <a class="btn btn-primary fsize a-btn" href="{{ route('password.request') }}">
+                                    {{ __('パスワードを忘れた方') }}
+                                </a>
+                            @endif
                         </div>
                     </form>
                 </div>

--- a/questionanswer/resources/views/auth/passwords/email.blade.php
+++ b/questionanswer/resources/views/auth/passwords/email.blade.php
@@ -2,10 +2,10 @@
 
 @section('content')
 <div class="container">
-    <div class="row justify-content-center">
+    <div class="row justify-content-center padding-auth">
         <div class="col-md-8">
             <div class="card">
-                <div class="card-header">{{ __('Reset Password') }}</div>
+                <div class="card-header">{{ __('パスワードのリセット') }}</div>
 
                 <div class="card-body">
                     @if (session('status'))
@@ -18,7 +18,7 @@
                         @csrf
 
                         <div class="form-group row">
-                            <label for="email" class="col-md-4 col-form-label text-md-right">{{ __('E-Mail Address') }}</label>
+                            <label for="email" class="col-md-4 col-form-label text-md-right">{{ __('メールアドレス') }}</label>
 
                             <div class="col-md-6">
                                 <input id="email" type="email" class="form-control @error('email') is-invalid @enderror" name="email" value="{{ old('email') }}" required autocomplete="email" autofocus>
@@ -31,12 +31,10 @@
                             </div>
                         </div>
 
-                        <div class="form-group row mb-0">
-                            <div class="col-md-6 offset-md-4">
-                                <button type="submit" class="btn btn-primary">
-                                    {{ __('Send Password Reset Link') }}
+                        <div class="form-group">
+                                <button type="submit" class="btn btn-primary fsize">
+                                    {{ __('リセット用リンク送信') }}
                                 </button>
-                            </div>
                         </div>
                     </form>
                 </div>

--- a/questionanswer/resources/views/auth/register.blade.php
+++ b/questionanswer/resources/views/auth/register.blade.php
@@ -2,7 +2,7 @@
 
 @section('content')
 <div class="container">
-    <div class="row justify-content-center">
+    <div class="row justify-content-center padding-auth">
         <div class="col-md-8">
             <div class="card">
                 <div class="card-header">{{ __('新規登録') }}</div>
@@ -61,12 +61,10 @@
                             </div>
                         </div>
 
-                        <div class="form-group row mb-0">
-                            <div class="col-md-6 offset-md-4">
-                                <button type="submit" class="btn btn-primary">
-                                    {{ __('登録') }}
-                                </button>
-                            </div>
+                        <div class="form-group">
+                            <button type="submit" class="btn btn-primary">
+                                {{ __('登録') }}
+                            </button>
                         </div>
                     </form>
                 </div>


### PR DESCRIPTION
ボタン中央寄せ・文字サイズ・リンクバグ修正、カード上部の隙間確保

[詳細]
login.bladeとregister.bladeとemail.bladeのボタンを覆うクラス(bootstrapの指定部分)を削除 5行目にpadding-auth追加
email.bladeとlogin.bladeのボタンにfsizeクラス追加
email.bladeの英語を日本語に変更(2箇所)
question.scss内の.btnの&.fsize追加（3行）&.a-btn追加（6行）40行目margin変更 61行目padding-top変更　.padding-auth追加（3行）
login.bladeのbuttonタグ削除 aタグにクラス追加,style属性削除